### PR TITLE
Fix MacOS M1/M2 installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,12 @@ then
     TARGET="${TARGET}linux"
 elif [ "$OS" = "Darwin" ]
 then
-    TARGET="${TARGET}macos"
+    if [ "${ARCH}" = "arm64" ]
+    then
+        TARGET="bkg-aarch64-macos"
+    else
+        TARGET="${TARGET}macos"
+    fi
 else
     echo "Unsupported OS/CPU"
     exit 1
@@ -20,7 +25,7 @@ fi
 URL="https://github.com/theseyan/bkg/releases/latest/download/"
 URL="${URL}${TARGET}"
 
-echo "Downloading bkg..."
+echo "Downloading bkg... $URL"
 curl --fail --location --progress-bar --output /usr/local/bin/bkg $URL
 chmod +x /usr/local/bin/bkg
 echo "bkg was successfully installed to /usr/local/bin/bkg"


### PR DESCRIPTION
${ARCH} is returning "arm64" instead of "aarch64" like it is on the release files. 
Fixing it.